### PR TITLE
Added support for <null> values in setLink* and setProperty, new method nextOrDefault() in traversals

### DIFF
--- a/totorom-tinkerpop2/src/main/java/org/jglue/totorom/FramedElement.java
+++ b/totorom-tinkerpop2/src/main/java/org/jglue/totorom/FramedElement.java
@@ -90,7 +90,11 @@ public abstract class FramedElement {
 	 *            The value of the property.
 	 */
 	protected void setProperty(String name, Object value) {
-		element.setProperty(name, value);
+		if (value == null) {
+			element.removeProperty(name);
+		} else {
+			element.setProperty(name, value);
+		}
 	}
 
 	/**

--- a/totorom-tinkerpop2/src/main/java/org/jglue/totorom/FramedVertex.java
+++ b/totorom-tinkerpop2/src/main/java/org/jglue/totorom/FramedVertex.java
@@ -166,7 +166,9 @@ public abstract class FramedVertex extends FramedElement {
 	 */
 	protected void setLinkOut(FramedVertex vertex, String... labels) {
 		unlinkOut(null, labels);
-		linkOut(vertex, labels);
+		if (vertex != null) {
+			linkOut(vertex, labels);
+		}
 	}
 	
 	/**
@@ -176,7 +178,9 @@ public abstract class FramedVertex extends FramedElement {
 	 */
 	protected void setLinkIn(FramedVertex vertex, String... labels) {
 		unlinkIn(null, labels);
-		linkIn(vertex, labels);
+		if (vertex != null) {
+			linkIn(vertex, labels);
+		}
 	}
 
 	
@@ -187,7 +191,9 @@ public abstract class FramedVertex extends FramedElement {
 	 */
 	protected void setLinkBoth(FramedVertex vertex, String... labels) {
 		unlinkBoth(null, labels);
-		linkBoth(vertex, labels);
+		if (vertex != null) {
+			linkBoth(vertex, labels);
+		}
 	}
 
 	/**

--- a/totorom-tinkerpop2/src/main/java/org/jglue/totorom/Traversal.java
+++ b/totorom-tinkerpop2/src/main/java/org/jglue/totorom/Traversal.java
@@ -742,6 +742,12 @@ public interface Traversal<T, Cap, SideEffect, Mark> extends Iterator<T>, Iterab
 	public abstract T next();
 
 	/**
+	 * Return the next object in the pipeline.
+	 *
+	 */
+	public abstract T nextOrDefault(T defaultValue);
+
+	/**
 	 * Return the next X objects in the pipeline as a list.
 	 *
 	 * @param number

--- a/totorom-tinkerpop2/src/main/java/org/jglue/totorom/TraversalBase.java
+++ b/totorom-tinkerpop2/src/main/java/org/jglue/totorom/TraversalBase.java
@@ -578,6 +578,15 @@ abstract class TraversalBase<T, Cap, SideEffect, Mark> implements Traversal<T, C
 		}
 		return (T) e;
 	}
+	
+	@Override
+	public T nextOrDefault(T defaultValue) {
+		if (pipeline().hasNext()) {
+			return next();
+		} else {
+			return defaultValue;
+		}
+	}
 
 	@Override
 	public EdgeTraversal start(FramedEdge object) {

--- a/totorom-tinkerpop2/src/main/java/org/jglue/totorom/VertexTraversal.java
+++ b/totorom-tinkerpop2/src/main/java/org/jglue/totorom/VertexTraversal.java
@@ -238,6 +238,18 @@ public interface VertexTraversal<Cap, SideEffect, Mark> extends Traversal<TVerte
 	public <N extends FramedVertex> N next(Class<N> kind);
 
 	/**
+	 * Get the next object emitted from the pipeline. If no such object exists,
+	 * then a the default value is returned.
+	 * 
+	 * @param kind
+	 *            The type of frame for the element.
+	 * @param defaultValue
+	 *            The object to return if no next object exists.
+	 * @return the next emitted object
+	 */
+	public <N extends FramedVertex> N nextOrDefault(Class<N> kind, N defaultValue);
+
+	/**
 	 * Get the next object emitted from the pipeline. If no such object exists a
 	 * new vertex is created.
 	 * 

--- a/totorom-tinkerpop2/src/main/java/org/jglue/totorom/VertexTraversalImpl.java
+++ b/totorom-tinkerpop2/src/main/java/org/jglue/totorom/VertexTraversalImpl.java
@@ -355,6 +355,15 @@ abstract class VertexTraversalImpl extends TraversalBase implements VertexTraver
 	public FramedVertex next(Class kind) {
 		return (FramedVertex) graph().frameElement((Element) pipeline().next(), kind);
 	}
+	
+	@Override
+	public FramedVertex nextOrDefault(Class kind, FramedVertex defaultValue) {
+		if (pipeline().hasNext()) {
+			return next(kind);
+		} else {
+			return defaultValue;
+		}
+	}
 
 	@Override
 	public FramedVertex nextOrAdd(Class kind) {

--- a/totorom-tinkerpop2/src/test/java/org/jglue/totorom/Program.java
+++ b/totorom-tinkerpop2/src/test/java/org/jglue/totorom/Program.java
@@ -1,0 +1,21 @@
+package org.jglue.totorom;
+
+public class Program extends FramedVertex {
+
+	public String getName() {
+		return getProperty("name");
+	}
+
+	public void setName(String name) {
+		setProperty("name", name);
+	}
+	
+	public String getLang() {
+		return getProperty("lang");
+	}
+
+	public void setLang(String lang) {
+		setProperty("lang", lang);
+	}
+
+}

--- a/totorom-tinkerpop2/src/test/java/org/jglue/totorom/TestFramedElement.java
+++ b/totorom-tinkerpop2/src/test/java/org/jglue/totorom/TestFramedElement.java
@@ -51,6 +51,18 @@ public class TestFramedElement {
     	Assert.assertEquals("Bryn", p1.getProperty("name"));
     }
     
+    @Test
+    public void testSetProperty() {
+    	p1.setProperty("name", "Bryn Cooke");
+    	Assert.assertEquals("Bryn Cooke", p1.getProperty("name"));
+    }
+    
+    @Test
+    public void testSetPropertyNull() {
+    	p1.setProperty("name", null);
+    	Assert.assertNull(p1.getProperty("name"));
+    }
+    
     
     @Test
     public void testV() {

--- a/totorom-tinkerpop2/src/test/java/org/jglue/totorom/TestFramedVertex.java
+++ b/totorom-tinkerpop2/src/test/java/org/jglue/totorom/TestFramedVertex.java
@@ -371,6 +371,19 @@ public class TestFramedVertex {
     }
 
     @Test
+	public void testSetLinkInNull() {
+		String label = "knows";
+		Person p3 = fg.addVertex(Person.class);
+		Person p4 = fg.addVertex(Person.class);
+		p3.setLinkIn(p4, label);
+		Assert.assertTrue("An out edge of type " + label + " must exist between vertices", p3.in(label).retain(Lists.newArrayList(p4)).count() > 0);
+		
+		// tests if setLinkOut accepts null values, and only unlinks the edges
+		p3.setLinkIn((FramedVertex) null, label);
+		Assert.assertEquals(label + " edge was not unlinked", 0, p3.in(label).count());
+	}
+
+	@Test
     public void testSetLinkOut(){
         String label = "knows";
         Person p3 = fg.addVertex(Person.class);
@@ -392,6 +405,19 @@ public class TestFramedVertex {
     }
 
     @Test
+	public void testSetLinkOutNull() {
+		String label = "knows";
+		Person p3 = fg.addVertex(Person.class);
+		Person p4 = fg.addVertex(Person.class);
+		p3.setLinkOut(p4, label);
+		Assert.assertTrue("An out edge of type " + label + " must exist between vertices", p3.out(label).retain(Lists.newArrayList(p4)).count() > 0);
+
+		// tests if setLinkOut accepts null values, and only unlinks the edges
+		p3.setLinkOut((FramedVertex) null, label);
+		Assert.assertEquals(label + " edge was not unlinked", 0, p3.out(label).count());
+	}
+
+	@Test
     public void testSetLinkBoth(){
         String label = "knows";
         Person p3 = fg.addVertex(Person.class);
@@ -416,6 +442,19 @@ public class TestFramedVertex {
         Assert.assertEquals(label + " out edge was not created", 1, p3.out(label).retain(Lists.newArrayList(p5)).count());
 
     }
+
+    @Test
+	public void testSetLinkBothNull() {
+		String label = "knows";
+		Person p3 = fg.addVertex(Person.class);
+		Person p4 = fg.addVertex(Person.class);
+		p3.setLinkBoth(p4, label);
+		Assert.assertTrue("An out edge of type " + label + " must exist between vertices", p3.both(label).retain(Lists.newArrayList(p4)).count() > 0);
+
+		// tests if setLinkOut accepts null values, and only unlinks the edges
+		p3.setLinkBoth((FramedVertex) null, label);
+		Assert.assertEquals(label + " edge was not unlinked", 0, p3.both(label).count());
+	}
 
     @Test
     public void testSetNewLinkIn(){

--- a/totorom-tinkerpop2/src/test/java/org/jglue/totorom/TestTraversals.java
+++ b/totorom-tinkerpop2/src/test/java/org/jglue/totorom/TestTraversals.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -436,5 +437,39 @@ public class TestTraversals {
 			}
 		}, 3).toList();
 		Assert.assertEquals(2, list.size());
+	}
+	
+	@Test
+	public void testNext() {
+		Assert.assertEquals(graph.v(3).next(), graph.v(6).out("created").next());
+	}
+
+	@Test(expected = NoSuchElementException.class)
+	public void testNextNoSuchElement() {
+		graph.v(6).out("knows").next();
+	}
+
+	@Test
+	public void testNextOrDefault() {
+		TVertex defaultValue = new TVertex(); 
+		Assert.assertEquals(graph.v(3).next(), graph.v(6).out("created").nextOrDefault(defaultValue));
+	}
+
+	@Test
+	public void testNextOrDefaultNoSuchElement() {
+		TVertex defaultValue = new TVertex(); 
+		Assert.assertEquals(defaultValue, graph.v(6).out("knows").nextOrDefault(defaultValue));
+	}
+	
+	@Test
+	public void testNextOrDefaultWithKind() {
+		Program defaultValue = new Program(); 
+		Assert.assertEquals(graph.v(3).next(Program.class), graph.v(6).out("created").nextOrDefault(Program.class, defaultValue));
+	}
+
+	@Test
+	public void testNextOrDefaultWithKindNoSuchElement() {
+		Person defaultValue = new Person(); 
+		Assert.assertEquals(defaultValue, graph.v(6).out("knows").nextOrDefault(Person.class, defaultValue));
 	}
 }


### PR DESCRIPTION
I completed my frames tot totorom migration and I like to propose these changes for supporting absent properties and links between vertices.
