### PR TITLE
Let FramedGraph return null when asked to frame an null element. 

### DIFF
--- a/totorom-tinkerpop2/src/main/java/org/jglue/totorom/FramedGraph.java
+++ b/totorom-tinkerpop2/src/main/java/org/jglue/totorom/FramedGraph.java
@@ -69,6 +69,9 @@ public class FramedGraph {
 	}
 
 	<T extends FramedElement> T frameElement(Element e, Class<T> kind) {
+		if(e == null){
+			return null;
+		}
 
 		Class<T> frameType = (kind == TVertex.class || kind == TEdge.class) ? kind : resolver.resolve(e, kind);
 

--- a/totorom-tinkerpop2/src/test/java/org/jglue/totorom/TestFramedElement.java
+++ b/totorom-tinkerpop2/src/test/java/org/jglue/totorom/TestFramedElement.java
@@ -80,6 +80,11 @@ public class TestFramedElement {
     }
     
     @Test
+    public void testvNull() {
+    	Assert.assertNull(p1.v("noId").next());
+    }
+    
+    @Test
     public void teste() {
     	Assert.assertEquals(e1, p1.e(e1.getId()).next(Knows.class));
     }


### PR DESCRIPTION
Hello Bryn,

I made some tests regarding isolation and wondered about retrieving an uncommitted object. I found that this was a behaviour of FramedGraph that just framed the null element from the underlying graph.
I have fixed this and added a test for it. I hope this is the correct behaviour now.

Best wishes,
Daniel
